### PR TITLE
add test for double centroid selection

### DIFF
--- a/src/koans/04_initialisation/00_input.rs
+++ b/src/koans/04_initialisation/00_input.rs
@@ -41,8 +41,32 @@ mod initialisation_input {
         assert!(centroids
             .genrows()
             .into_iter()
-            .all(|centroid| is_row_of(&observations, &centroid)));
+            .all(|centroid| is_row_of(&observations, &centroid)), "Centroids should be a subset of our observations");
     }
+
+
+    // Helper function nr 2.
+    // Check if there is only one row in `matrix` that is equal to `row`
+    fn is_unique_in(matrix: &Array2<f64>, row: &ArrayView1<f64>) -> bool {
+        matrix.genrows().into_iter().filter(|r| r == row).count() == 1
+    }
+
+    #[test]
+    fn test_unique_centroids() {
+        let mut rng = Isaac64Rng::seed_from_u64(42);
+        let n_observations = 100;
+        let n_clusters = 99; // provoke double selection
+        let observations: Array2<f64> =
+            Array::random_using((n_observations, n_clusters), StandardNormal, &mut rng);
+
+        let centroids = get_random_centroids(n_clusters, observations.view(), &mut rng);
+
+        assert!(centroids
+            .genrows()
+            .into_iter()
+            .all(|centroid| is_unique_in(&centroids, &centroid)), "centroids should be unique");
+    }
+
 
     #[test]
     #[should_panic]


### PR DESCRIPTION
invalidates solutions like

pub fn get_random_centroids(
    n_clusters: usize,
    observations: ArrayView2<f64>,
    rng: &mut impl Rng,
) -> Array2<f64> {
    let (n_observations, _) = observations.dim();
    assert!(n_observations > n_clusters, "we need more observations than clusters!");

    let sample_points = Array::random_using(n_clusters, Uniform::new(0, n_observations), rng);

    observations.select(Axis(0), sample_points.as_slice().unwrap())
}